### PR TITLE
fix to lower Automat dependency version for python 2 environments

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,15 @@ else
     version node['mimic']['version'] unless node['mimic']['version'].nil?
     virtualenv venv
   end
+  # Automat versions beyond 20.2.0 do not work with Python 2. Until we migrate to python-3 override the
+  # dependency installed with mimic
+  if node['Automat']
+    python_pip 'Automat' do
+      action :install
+      version node['Automat']['version'] unless node['Automat']['version'].nil?
+      virtualenv venv
+    end
+  end
 end
 
 runit_service 'mimic' do


### PR DESCRIPTION
[Mimic](https://github.com/rackerlabs/mimic) installed via [Chef cookbook](https://github.com/rackerlabs/cookbook-mimic) on the main ELE dev box and buildbot slaves is broken. A [recent change to automat](https://github.com/glyph/automat/commit/ff3ecd5159079d60095b1d1116117d635433c6a3#diff-1d8b94589bfcb9d53a8fe73dc3988f9da778895b7bd928eb35d4ed98d927c423L7-R7) has broken mimic. When started, it quickly fails with
```
File "/data/mimic-env/lib/python2.7/site-packages/automat/_methodical.py", line 7, in <module>
    from inspect import getfullargspec as getArgsSpec

```
because of the removal of the clause that makes it work in Python 2.
Downgrading Automat to 20.2.0, released Feb 16, 2020, seems to make things work. That was the [most recent release on pypi](https://pypi.org/project/Automat/#history) before 22.10.0, which came out Oct 29, 2022, and is probably what broke stuff.

This PR allows chef to override Automat to specific version (like 20.2.0) for python 2 to breath