### PR TITLE
override Automat dependency in rax-dev-vm provisioning

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,14 +32,15 @@ else
     version node['mimic']['version'] unless node['mimic']['version'].nil?
     virtualenv venv
   end
-  # Automat versions beyond 20.2.0 do not work with Python 2. Until we migrate to python-3 override the
-  # dependency installed with mimic
-  if node['Automat']
-    python_pip 'Automat' do
-      action :install
-      version node['Automat']['version'] unless node['Automat']['version'].nil?
-      virtualenv venv
-    end
+end
+
+# Automat versions beyond 20.2.0 do not work with Python 2. Until we migrate to python-3 override the
+# dependency installed with mimic
+if node['Automat']
+  python_pip 'Automat' do
+    action :install
+    version node['Automat']['version'] unless node['Automat']['version'].nil?
+    virtualenv venv
   end
 end
 


### PR DESCRIPTION
Apply Automat override for dev vm and slave vms.

Dev VM output:
```
vagrant@dev-maas-dev-dev0:~$ sudo su -
root@dev-maas-dev-dev0..dev:~ $ . /data/mimic-env/bin/activate
(mimic-env) root@dev-maas-dev-dev0..dev:~ $ pip show Automat
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Name: Automat
Version: 20.2.0
Summary: Self-service finite-state machines for the programmer on the go.
Home-page: https://github.com/glyph/Automat
Author: Glyph
Author-email: glyph@twistedmatrix.com
License: MIT
Location: /data/mimic-env/lib/python2.7/site-packages
Requires: attrs, six
```

Buildbot slave VM:
```
vagrant@vagrant-buildbot-app-slave-14:~$ source /data/mimic-env/bin/activate
(mimic-env) vagrant@vagrant-buildbot-app-slave-14:~$ pip show Automat
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Name: Automat
Version: 20.2.0
Summary: Self-service finite-state machines for the programmer on the go.
Home-page: https://github.com/glyph/Automat
Author: Glyph
Author-email: glyph@twistedmatrix.com
License: MIT
Location: /data/mimic-env/lib/python2.7/site-packages
Requires: attrs, six
Required-by: Twisted
(mimic-env) vagrant@vagrant-buildbot-app-slave-14:~$ 
```
