### PR TITLE
remove dependency on python cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@lists.rackspace.com'
 license          'Apache 2.0'
 description      'Installs/Configures mimic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.5'
+version          '0.0.6'
 
 supports 'ubuntu'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,4 @@ version          '0.0.5'
 
 supports 'ubuntu'
 
-depends 'python'
 depends 'runit'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,6 +53,7 @@ if node['Automat']
       source #{venv}/bin/activate
       #{automat_install_string}
     CODE
+  end
 end
 
 runit_service 'mimic' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,6 @@
-include_recipe 'python'
 include_recipe 'runit'
 
+package 'python-virtualenv'
 venv = node['mimic']['virtualenv']
 
 %w(libffi6 libffi-dev).each do |pkg|
@@ -10,10 +10,13 @@ venv = node['mimic']['virtualenv']
 end
 
 # recreate virtualenv
-[:delete, :create].each do |todo|
-  python_virtualenv venv do
-    action todo
-  end
+bash "delete virtualenv #{venv}" do
+  code "rm -rf #{venv}"
+  only_if { ::File.directory?(venv) }
+end
+
+bash "create virtualenv #{venv}" do
+  code "virtualenv #{venv}"
 end
 
 # install mimic
@@ -27,21 +30,29 @@ if node['mimic']['dev']
     CODE
   end
 else
-  python_pip 'mimic' do
-    action :install
-    version node['mimic']['version'] unless node['mimic']['version'].nil?
-    virtualenv venv
-  end
+  mimic_version = node['mimic']['version']
+  mimic_install_string = 'pip install mimic'
+  mimic_install_string += "==#{mimic_version}" unless mimic_version.nil?
+
+  bash 'install mimic' do
+    code  <<-CODE
+      source #{venv}/bin/activate
+      #{mimic_install_string}
+    CODE
 end
 
 # Automat versions beyond 20.2.0 do not work with Python 2. Until we migrate to python-3 override the
 # dependency installed with mimic
 if node['Automat']
-  python_pip 'Automat' do
-    action :install
-    version node['Automat']['version'] unless node['Automat']['version'].nil?
-    virtualenv venv
-  end
+  automat_version = node['Automat']['version']
+  automat_install_string = 'pip install Automat'
+  automat_install_string += "==#{automat_version}" unless automat_version.nil?
+
+  bash 'install Automat' do
+    code <<-CODE
+      source #{venv}/bin/activate
+      #{automat_install_string}
+    CODE
 end
 
 runit_service 'mimic' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,7 @@ else
       source #{venv}/bin/activate
       #{mimic_install_string}
     CODE
+  end
 end
 
 # Automat versions beyond 20.2.0 do not work with Python 2. Until we migrate to python-3 override the


### PR DESCRIPTION
the python cookbook has been deprecated since 2014, lets
remove our usage of it. removing it will also allow the this
cookbook to be used with chef 13+
