### PR TITLE
version bump 0.0.7

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@lists.rackspace.com'
 license          'Apache 2.0'
 description      'Installs/Configures mimic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.6'
+version          '0.0.7'
 
 supports 'ubuntu'
 


### PR DESCRIPTION
only the version has been updated, this is to allow for a new release
for changes that happened in 4f1071e, which were not accounted for due
to the 0.0.6 release happening before 4f1071e was merged.
